### PR TITLE
Feat/add oauth route

### DIFF
--- a/src/routes/loginRouter.ts
+++ b/src/routes/loginRouter.ts
@@ -256,7 +256,7 @@ loginRouter.post('/oauth', async (req, res) => {
 
             if (SECRET) {
                 const token = jwt.sign(userToken, SECRET, {expiresIn: "6h"})
-                return res.status(200).json({ message: 'Usuario verificado con exito. Redirigiendo...', token, username: newUser.username, tipo_user: newUser.tipo_user, user_id: newUser.id_usuario, method: 'firebase' })
+                return res.status(200).json({ message: 'Usuario creado y verificado con exito. Redirigiendo...', token, username: newUser.username, tipo_user: newUser.tipo_user, user_id: newUser.id_usuario, method: 'firebase' })
             } else {
                 return res.status(500).json({ message: 'No se pudo generar el token de autenticación.' })
             }

--- a/src/routes/loginRouter.ts
+++ b/src/routes/loginRouter.ts
@@ -220,19 +220,19 @@ loginRouter.post('/oauth', async (req, res) => {
     try {
         const [row, fields] = await connection.query(`SELECT * FROM usuario WHERE correo = ?`, [req.body.email])
 
-        const user = row as mysql.RowDataPacket[]
+        const { username, id_usuario, tipo_user } = row as mysql.RowDataPacket[][0]
 
-        if (Array.isArray(user) && user.length > 0) {            
+        if (id_usuario) {            
             const userToken = {
-                username: user[0].username,
-                identifier: user[0].id_usuario
+                username: username,
+                identifier: id_usuario
             }
 
             if (SECRET) {
                 const token = jwt.sign(userToken, SECRET, {expiresIn: "6h"})
-                return res.status(200).json({ message: 'Usuario verificado con exito. Redirigiendo...', token, username: user[0].username, tipo_user: user[0].tipo_user, user_id: user[0].id_usuario, method: 'firebase' })
+                return res.status(200).json({ message: 'Usuario verificado con exito. Redirigiendo...', token, username: username, tipo_user: tipo_user, user_id: id_usuario, method: 'google' })
             } else {
-                return res.status(500).json({ message: 'No se pudo generar el token de autenticación.' })
+                return res.status(500).json({ message: 'No se pudo generar el token de autenticación, intente más tarde.' })
             }
         } else {
             const newUser = {
@@ -256,7 +256,7 @@ loginRouter.post('/oauth', async (req, res) => {
 
             if (SECRET) {
                 const token = jwt.sign(userToken, SECRET, {expiresIn: "6h"})
-                return res.status(200).json({ message: 'Usuario creado y verificado con exito. Redirigiendo...', token, username: newUser.username, tipo_user: newUser.tipo_user, user_id: newUser.id_usuario, method: 'firebase' })
+                return res.status(200).json({ message: 'Usuario creado y verificado con éxito. Redirigiendo...', token, username: newUser.username, tipo_user: newUser.tipo_user, user_id: newUser.id_usuario, method: 'google' })
             } else {
                 return res.status(500).json({ message: 'No se pudo generar el token de autenticación.' })
             }

--- a/src/utils/encrypt.ts
+++ b/src/utils/encrypt.ts
@@ -1,0 +1,6 @@
+export const encrypt = () => {
+  const array = new Uint8Array(5)
+  crypto.getRandomValues(array)
+
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join('')
+}


### PR DESCRIPTION
# Añadir ruta para google auth

## ¿Por qué se hizo? 🥸

🔗 Para que el sistema pueda guardar aquellos usuarios que intenten iniciar sesión con google.

## ¿Qué se hizo? 🪚

Se agregó una nueva ruta en loginRouter, la cual verifica si el email del usuario existe en la base de datos. Si no existe, se creará el registro con una contraseña encriptada, pero no hasheada (debido a que el proceso del login siempre intenta verificar la contraseña por medio de hashes, la nueva contraseña no coincidirá nunca, haciendo que solo se pueda iniciar sesión mediante google).
También, en la ruta api/login/verify (la que se utiliza para iniciar sesión normalmente) y en la nueva ruta agregada, se devolverá un nuevo atributo `method`, el cual indicará si el usuario inició sesión con firebase. El atributo se utilizará en el frontend para cerrar la sesión.
PR con los cambios del frontend: https://github.com/IgnacioBarraza/BlackSharkWeb/pull/94

## ¿Cómo se prueba esto? 🧪

1- `npm i` y `npm run dev`.
2- Hacer una request a /api/login/oauth, pasando en el body un correo y un nombre de usuario:
```
{
	"email": "email",
	"username": "username"
}
```
4- Si el usuario no existe, debería aparecer un mensaje informando que se creó y verificó el usuario. En caso de que el usuario sí exista, debería devolver que el usuario fue verificado. En ambios casos, deben estar los atributos `message`, `token`, `username`, `tipo_user`, `user_id` y `method`.